### PR TITLE
don't clean on import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,15 @@ all: clean images
 images:
 	cd images && $(MAKE) -f Makefile VERSION=$(VER)
 
+.PHONY: import
+import: images
+	-gravity app delete --ops-url=$(OPS_URL) $(REPOSITORY)/$(NAME):$(VER) --force --insecure
+	gravity app import $(IMPORT_OPTIONS) .
+
+.PHONY: clean
+clean:
+	-rm images/bootstrap/pithosboot
+
 .PHONY: dev-push
 dev-push: images
 	for container in $(CONTAINERS); do \
@@ -52,12 +61,3 @@ dev-clean:
 	-kubectl delete -f dev/pithos.yaml
 	-kubectl delete configmap cassandra-cfg pithos-cfg
 	-kubectl label nodes -l pithos-role=node pithos-role-
-
-.PHONY: import
-import: clean images
-	-gravity app delete --ops-url=$(OPS_URL) $(REPOSITORY)/$(NAME):$(VER) --force --insecure
-	gravity app import $(IMPORT_OPTIONS) .
-
-.PHONY: clean
-clean:
-	-rm images/bootstrap/pithosboot


### PR DESCRIPTION
Minor change in Makefile:
- don't clean on import target, 'cause it deletes already builded binary produced by make
- small reordering, got dev targets together
