### PR TITLE
Jeff/upgrade cassandra

### DIFF
--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -20,6 +20,8 @@ RUN gpg --keyserver pgp.mit.edu --recv-keys F758CE318D77295D && \
   gpg --export --armor F758CE318D77295D | apt-key add - && \
   gpg --keyserver pgp.mit.edu --recv-keys 2B5C1B00 && \
   gpg --export --armor 2B5C1B00 | apt-key add - && \
+  gpg --keyserver pgp.mit.edu --recv-keys A278B781FE4B2BDA && \
+  gpg --export --armor A278B781FE4B2BDA | apt-key add - && \
   gpg --keyserver pgp.mit.edu --recv-keys 0353B12C && \
   gpg --export --armor 0353B12C | apt-key add - && \
   apt-get update && \

--- a/images/cassandra/cassandra.list
+++ b/images/cassandra/cassandra.list
@@ -1,5 +1,5 @@
-deb http://www.apache.org/dist/cassandra/debian 35x main
-deb-src http://www.apache.org/dist/cassandra/debian 35x main
+deb http://www.apache.org/dist/cassandra/debian 39x main
+deb-src http://www.apache.org/dist/cassandra/debian 39x main
 
 # for jre8
 deb http://http.debian.net/debian jessie-backports main


### PR DESCRIPTION
Specifically we need a fix in 3.7 (https://issues.apache.org/jira/browse/CASSANDRA-11742), but it should be safe to go to 3.9 as well.