### PR TITLE
Grew Cassandra memory heap settings

### DIFF
--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -41,9 +41,9 @@ spec:
           imagePullPolicy: Always
           env:
             - name: MAX_HEAP_SIZE
-              value: 512M
+              value: 2048M
             - name: HEAP_NEWSIZE
-              value: 100M
+              value: 256M
             - name: CASSANDRA_OPEN_JMX
               value: "true"
             - name: CASSANDRA_CLUSTER_NAME


### PR DESCRIPTION
Grew Cassandra memory heap settings to avoid issues during the backup process.

I'm proposing this little change to be tag/1.6.1