### PR TITLE
Added SecurityContext to restore UID:0 usage inside containers

### DIFF
--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -93,6 +93,8 @@ spec:
         pithos-role: cassandra
         component: cassandra
     spec:
+      securityContext:
+        runAsUser: 0
       serviceAccountName: cassandra
       nodeSelector:
         pithos-role: node

--- a/resources/pithos-initialize.yaml
+++ b/resources/pithos-initialize.yaml
@@ -7,6 +7,8 @@ spec:
     metadata:
       name: pithos-initialize
     spec:
+      securityContext:
+        runAsUser: 0
       restartPolicy: OnFailure
       containers:
         - image: cassandra:latest


### PR DESCRIPTION
Added SecurityContext to restore UID:0 usage inside containers, since none of this containers are ready/tested to be run as non-root-users.