### PR TITLE
Fix cassandra nodetool usage (changed repair timing, removed compact)

### DIFF
--- a/images/cassandra/rootfs/cassandra-status.sh
+++ b/images/cassandra/rootfs/cassandra-status.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/nodetool -p 7199 -h cassandra.default.svc status -r | tail -n +6 | head -n -1 | /usr/bin/gawk -f /cassandra-status.awk
+/usr/bin/nodetool -p 7199 -h localhost status -r | tail -n +6 | head -n -1 | /usr/bin/gawk -f /cassandra-status.awk

--- a/images/cassandra/rootfs/usr/sbin/start-utils.sh
+++ b/images/cassandra/rootfs/usr/sbin/start-utils.sh
@@ -4,7 +4,7 @@ if [ "x$CRON_SCHEDULE" = "x" ]; then
     CRON_SCHEDULE='0 0 * * *'
 fi
 
-echo "$CRON_SCHEDULE "'root nodetool -p 7199 -h localhost repair && nodetool -p 7199 -h localhost compact >> /var/log/cron.log 2>&1' > /etc/cron.d/cassandra
+echo "$CRON_SCHEDULE "'root sleep $[RANDOM%30]m && nodetool -p 7199 -h localhost repair >> /var/log/cron.log 2>&1' > /etc/cron.d/cassandra
 
 # create telegraf user
 curl -XPOST "http://influxdb.kube-system.svc:8086/query?u=root&p=root" \


### PR DESCRIPTION
Fix cassandra nodetool usage:
- added random delay to the cronjob to spread the load on different nodes
- removed explicit compact-ion as it's not needed

Fixed telegraf endpoint to be localhost instead of the Cassandra SVC.