### PR TITLE
Several fixes for update hook after bumping rig version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ TELE_BUILD_OPTIONS := --insecure \
                 --ignore=".git" \
                 --ignore="images" \
                 --ignore="tool" \
+                --ignore="pithos-cfg" \
                 $(IMPORT_IMAGE_FLAGS)
 
 BUILD_DIR := build

--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/rig:0.0.6
+FROM quay.io/gravitational/rig:0.0.10
 
 ARG CHANGESET
 ENV RIG_CHANGESET $CHANGESET

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -13,11 +13,7 @@ if [ $1 = "update" ]; then
     sed -i 's/localhost/cassandra.default.svc.cluster.local/' pithoscfg.yaml
     kubectl apply -f pithoscfg.yaml
 
-    if kubectl get configmap cassandra-cfg > /dev/null 2>&1
-    then
-        kubectl delete configmap cassandra-cfg
-    fi
-
+    rig delete configmaps/cassandra-cfg --force
     rig delete deployments/pithos --force
     rig delete deployments/cassandra-utils --force
 

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -13,7 +13,11 @@ if [ $1 = "update" ]; then
     sed -i 's/localhost/cassandra.default.svc.cluster.local/' pithoscfg.yaml
     kubectl apply -f pithoscfg.yaml
 
-    rig delete configmap/cassandra-cfg --force
+    if kubectl get configmap cassandra-cfg > /dev/null 2>&1
+    then
+        kubectl delete configmap cassandra-cfg
+    fi
+
     rig delete deployments/pithos --force
     rig delete deployments/cassandra-utils --force
 

--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -86,6 +86,11 @@ metadata:
     app: pithos
     pithos-role: cassandra
 spec:
+  selector:
+    matchLabels:
+      app: pithos
+      pithos-role: cassandra
+      component: cassandra
   template:
     metadata:
       labels:

--- a/resources/pithos.yaml
+++ b/resources/pithos.yaml
@@ -85,6 +85,11 @@ metadata:
     app: pithos
     pithos-role: pithos
 spec:
+  selector:
+    matchLabels:
+      app: pithos
+      pithos-role: pithos
+      component: pithos
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
I've bumped rig, because old one sometimes fails on k8s 1.9.