### PR TITLE
Fix intermittently failing installations or upgrades.

### DIFF
--- a/internal/pithosctl/pkg/cassandra/cassandra.go
+++ b/internal/pithosctl/pkg/cassandra/cassandra.go
@@ -110,7 +110,7 @@ func GetStatus(statusOutput string) (map[string]*Status, error) {
 }
 
 func processNode(line string) (*Status, error) {
-	reNodeStatus := regexp.MustCompile(`^(?P<status>[A-Z])(?P<state>[A-Z])\s+?(?P<ip>(?:[0-9]{1,3}\.){3}[0-9]{1,3})\s+(?P<load>[0-9\.\?]+)\s+(?P<load_units>[A-Za-z]+)?\s+(?P<tokens>[0-9]+)\s+(?P<owns>[0-9\.%]+)\s+(?P<uuid>[a-f\-0-9]+)\s+(?P<rack>.*)$`)
+	reNodeStatus := regexp.MustCompile(`^(?P<status>[A-Z])(?P<state>[A-Z])\s+?(?P<ip>(?:[0-9]{1,3}\.){3}[0-9]{1,3})\s+(?P<load>[0-9\.\?]+)\s+(?P<load_units>[A-Za-z]+)?\s+(?P<tokens>[0-9]+)\s+(?P<owns>[0-9\.]+)%\s+(?P<uuid>[a-f\-0-9]+)\s+(?P<rack>.*)$`)
 	fields := reNodeStatus.FindAllStringSubmatch(line, -1)
 
 	ownsPercentage, err := strconv.ParseFloat(fields[0][7], 32)

--- a/resources/app.yaml
+++ b/resources/app.yaml
@@ -8,13 +8,13 @@ metadata:
 
 dependencies:
   apps:
-    - gravitational.io/cluster-ssl-app:0.0.0+latest
+    - gravitational.io/cluster-ssl-app:0.8.2-5.5.24
 
 systemOptions:
   docker:
     storageDriver: overlay
   runtime:
-    version: "0.0.0+latest"
+    version: "5.2.12"
 
 installer:
   flavors:
@@ -118,6 +118,7 @@ hooks:
         name: pithos-app-post-install
         namespace: default
       spec:
+        backoffLimit: 10
         parallelism: 1
         completions: 1
         template:
@@ -170,6 +171,7 @@ hooks:
         name: pithos-app-post-update
         namespace: default
       spec:
+        backoffLimit: 10
         parallelism: 1
         completions: 1
         template:

--- a/resources/app.yaml
+++ b/resources/app.yaml
@@ -8,13 +8,13 @@ metadata:
 
 dependencies:
   apps:
-    - gravitational.io/cluster-ssl-app:0.8.2-5.5.24
+    - gravitational.io/cluster-ssl-app:0.0.0+latest
 
 systemOptions:
   docker:
     storageDriver: overlay
   runtime:
-    version: "5.2.12"
+    version: "0.0.0+latest"
 
 installer:
   flavors:


### PR DESCRIPTION
* `nodetool status` can output node without load. Replace parser with
regex implementation.