### PR TITLE
Fix health check

### DIFF
--- a/images/cassandra/rootfs/etc/telegraf/telegraf.conf
+++ b/images/cassandra/rootfs/etc/telegraf/telegraf.conf
@@ -259,3 +259,8 @@
     mbean = "org.apache.cassandra.metrics:name=*,path=*,scope=*,type=ThreadPools"
     tag_keys = ["name", "path", "scope"]
     field_prefix = "$1_"
+
+[[inputs.jolokia2_agent.metric]]
+    name  = "JavaMemory"
+    mbean = "java.lang:type=Memory"
+    field_prefix = "$1_"

--- a/images/cassandra/rootfs/etc/telegraf/telegraf.conf
+++ b/images/cassandra/rootfs/etc/telegraf/telegraf.conf
@@ -260,7 +260,7 @@
     tag_keys = ["name", "path", "scope"]
     field_prefix = "$1_"
 
-[[inputs.jolokia2_agent.metric]]
+  [[inputs.jolokia2_agent.metric]]
     name  = "JavaMemory"
     mbean = "java.lang:type=Memory"
     field_prefix = "$1_"

--- a/images/cassandra/rootfs/run.sh
+++ b/images/cassandra/rootfs/run.sh
@@ -160,6 +160,9 @@ if [[ $CASSANDRA_GC_STDOUT == 'true' ]]; then
   sed -i '/-Xloggc/d' $CASSANDRA_CONF_DIR/cassandra-env.sh
 fi
 
+# print heap histogram on OutOfMemoryError
+sed -ri "/^#.*cassandra.printHeapHistogramOnOutOfMemoryError/s/^# //" $CASSANDRA_CONF_DIR/cassandra-env.sh
+
 # enable RMI and JMX to work on one port
 echo "JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=$POD_IP\"" >> $CASSANDRA_CONF_DIR/cassandra-env.sh
 

--- a/images/pithos/run.sh
+++ b/images/pithos/run.sh
@@ -5,7 +5,9 @@ set -o errexit
 
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre
 export PASSWORD_FOR_JAVA_TRUSTSTORE='changeit'
+export MAX_HEAP_SIZE=${MAX_HEAP_SIZE:-1024M}
+export JVM_OPTS="-XX:+UseG1GC -Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE}"
 
 keytool -import -trustcacerts -keystore ${JAVA_HOME}/lib/security/cacerts -alias cassandra-node -import -file ${CASSANDRA_CERT_FILE} -storepass ${PASSWORD_FOR_JAVA_TRUSTSTORE} -noprompt || true
 
-dumb-init java -jar /pithos.jar -f /etc/pithos/config.yaml
+dumb-init java ${JVM_OPTS} -jar /pithos.jar -f /etc/pithos/config.yaml

--- a/internal/pithosctl/pkg/pithos/healthz.go
+++ b/internal/pithosctl/pkg/pithos/healthz.go
@@ -142,6 +142,12 @@ func (h *Healthz) createObject() error {
 }
 
 func (h *Healthz) GetObject() error {
-	_, err := h.Client.GetObject(h.Bucket, objectName, minio.GetObjectOptions{})
+	reader, err := h.Client.GetObject(h.Bucket, objectName, minio.GetObjectOptions{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var data []byte
+	_, err = reader.Read(data)
 	return trace.Wrap(err)
 }

--- a/internal/pithosctl/pkg/pithos/healthz.go
+++ b/internal/pithosctl/pkg/pithos/healthz.go
@@ -146,6 +146,7 @@ func (h *Healthz) GetObject() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer reader.Close()
 
 	var data []byte
 	_, err = reader.Read(data)

--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -161,8 +161,6 @@ spec:
           env:
             - name: MAX_HEAP_SIZE
               value: 2048M
-            - name: HEAP_NEWSIZE
-              value: 256M
             - name: CASSANDRA_SEEDS
               value: "cassandra-0.cassandra.default.svc.cluster.local"
             - name: CASSANDRA_CLUSTER_NAME

--- a/resources/pithos.yaml
+++ b/resources/pithos.yaml
@@ -125,6 +125,16 @@ spec:
         env:
           - name: CASSANDRA_CERT_FILE
             value: /etc/cassandra-ssl/cassandra-node.cer
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 120
+          periodSeconds: 60
+          # slightly higher than the timeout configured in pithos.conf
+          # https://github.com/gravitational/pithos-app/blob/master/resources/pithos-cfg/config.yaml.template#L118
+          # read-timeout-millis: 30000
+          timeoutSeconds: 32
       - image: pithos-proxy:latest
         name: proxy
         ports:
@@ -168,16 +178,6 @@ spec:
               secretKeyRef:
                 name: pithos-keys
                 key: master.secret
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 120
-          periodSeconds: 60
-          # slightly higher than the timeout configured in pithos.conf
-          # https://github.com/gravitational/pithos-app/blob/master/resources/pithos-cfg/config.yaml.template#L118
-          # read-timeout-millis: 30000
-          timeoutSeconds: 32
       volumes:
         - name: pithos-cfg
           configMap:


### PR DESCRIPTION
This PR is solving a few issues with application:
1. By default pithos application has no limits for memory and looks like the system does not reclaim it.
2. Health creates only minio.Object and don't actually read it. So, it was just a noop operation.
3. livenessProbe was attached to the wrong container.

As a plus Java memory metrics collection was added into Cassandra container.