### PR TITLE
Allow of use non read-only root filesystem

### DIFF
--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -16,6 +16,7 @@ spec:
     rule: RunAsAny
   fsGroup:
     rule: RunAsAny
+  readOnlyRootFilesystem: false
   allowedCapabilities:
   - IPC_LOCK
   volumes:
@@ -148,6 +149,7 @@ spec:
           name: cassandra
           imagePullPolicy: Always
           securityContext:
+            readOnlyRootFilesystem: false
             capabilities:
               add:
                 - IPC_LOCK


### PR DESCRIPTION
Cassandra container entrypoint changes some files in `/etc/cassandra` and root filesystem should be writable.