### PR TITLE
Delete cassandra-alter-compaction job during upgrade

### DIFF
--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -16,6 +16,7 @@ if [ $1 = "update" ]; then
     rig delete configmaps/rollups-pithos --resource-namespace=monitoring --force
     rig delete configmaps/pithos-alerts --resource-namespace=monitoring --force
     rig delete configmaps/cassandra --force
+    rig delete jobs/cassandra-alter-compaction --force
 
     ## copy telegraf secret from monitoring namespace
     if kubectl --namespace=monitoring get secret telegraf-influxdb-creds >/dev/null 2>&1;
@@ -39,7 +40,9 @@ if [ $1 = "update" ]; then
     echo "Checking status"
     rig status $RIG_CHANGESET --retry-attempts=120 --retry-period=2s --debug
     echo "Updating cassandra compaction settings for storage.block column family"
-    kubectl apply -f /var/lib/gravity/resources/cassandra-alter-compaction.yaml
+    rig upsert -f /var/lib/gravity/resources/cassandra-alter-compaction.yaml
+    echo "Checking status after applying the job"
+    rig status $RIG_CHANGESET --retry-attempts=120 --retry-period=2s --debug
     echo "Freezing"
     rig freeze
 elif [ $1 = "rollback" ]; then


### PR DESCRIPTION
----

Delete the job, which could be created in previous version and upgrade
would fail with `already exist` error.