### PR TITLE
Change Jenkins to use the branch related to the PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ properties([
   disableConcurrentBuilds(),
   parameters([
     string(name: 'TAG',
-           defaultValue: 'master',
+           defaultValue: env.BRANCH_NAME,
            description: 'Git tag to build'),
     choice(choices: ["run", "skip"].join("\n"),
            description: 'Run or skip robotest system wide tests.',


### PR DESCRIPTION
I propose to change Jenkins to use the branch related to the PR, instead of building off of master by default