### PR TITLE
Run build/robotest containers as non-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GRAVITY_VERSION ?= 5.5.21
 CLUSTER_SSL_APP_VERSION ?= "0.0.0+latest"
 
 SRCDIR=/go/src/github.com/gravitational/pithos-app
-DOCKERFLAGS=--rm=true -v $(PWD):$(SRCDIR) -v $(GOPATH)/pkg:/gopath/pkg -w $(SRCDIR)
+DOCKERFLAGS=--rm=true -u $$(id -u):$$(id -g) -e GOCACHE=/tmp/.cache -v $(PWD):$(SRCDIR) -v $(GOPATH)/pkg:/gopath/pkg -w $(SRCDIR)
 BUILDIMAGE=quay.io/gravitational/debian-venti:go1.12.9-buster
 
 EXTRA_GRAVITY_OPTIONS ?=

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -28,7 +28,13 @@ export GCE_VM=${GCE_VM:-custom-4-8192}
 export PARALLEL_TESTS=${PARALLEL_TESTS:-4}
 export REPEAT_TESTS=${REPEAT_TESTS:-1}
 export RETRIES=${RETRIES:-1}
-export DOCKER_RUN_FLAGS=${DOCKER_RUN_FLAGS:-"-u $(id -u)"}
+export DOCKER_RUN_FLAGS=${DOCKER_RUN_FLAGS:-"--rm=true --user=$(id -u):$(id -g)"}
+
+# Work around a bug in https://github.com/gravitational/robotest/blob/v2.1.0/docker/suite/run_suite.sh#L21-L30
+# which mounts a volume inside a volume, resulting in docker creating the inner mountpoint
+# owned by root:root if it does not already exist.
+INSTALLER_BINDIR="$(dirname ${INSTALLER_URL})/bin"
+mkdir -p "${INSTALLER_BINDIR}"
 
 # set SUITE and UPGRADE_VERSIONS
 case $TARGET in


### PR DESCRIPTION
Jenkins is having trouble cleaning up after pithos PR builds due to docker creating some files as root:

```
[jenkins@jenkins workspace]$ find Pithos* \! -user jenkins -print
Pithos_master-4EXACQGM7TB7GGIYDLWQ2PR5IZEWVEL73KPVGMBLGYYHEVJEVNYQ/upgrade_from
Pithos_master-4EXACQGM7TB7GGIYDLWQ2PR5IZEWVEL73KPVGMBLGYYHEVJEVNYQ/upgrade_from/installer_1.0.0.tar
Pithos_PR-128-PVD7BCU3743PVG4MMLITS64FF6FEND3BJKWACD25AY6A6JXHYF5Q-10/build/pithosctl
Pithos_PR-128-PVD7BCU3743PVG4MMLITS64FF6FEND3BJKWACD25AY6A6JXHYF5Q-10/build/bin
Pithos_PR-128-PVD7BCU3743PVG4MMLITS64FF6FEND3BJKWACD25AY6A6JXHYF5Q-15/build/pithosctl
Pithos_PR-128-PVD7BCU3743PVG4MMLITS64FF6FEND3BJKWACD25AY6A6JXHYF5Q-15/build/bin
Pithos_PR-128-PVD7BCU3743PVG4MMLITS64FF6FEND3BJKWACD25AY6A6JXHYF5Q-8/build/pithosctl
Pithos_PR-128-PVD7BCU3743PVG4MMLITS64FF6FEND3BJKWACD25AY6A6JXHYF5Q-8/build/bin
...
```



This fixes `pithosctl` (the first commit) and `build/bin` (the second commit).  I'm not sure what is up with `upgrade_from` but I believe it was fixed by 335f955e67bb5820d6f371010cdd20b4dee2be4b.

I manually cleaned up ~.5TB of files this morning -- and will catch the rest once this merges into all relevant branches (1.12.x?)

# Testing Done
Before
```
walt@work:~/git/pithos-app$ make build-pithosctl                                                                                                                                              
mkdir -p build                                                                                 
docker run --rm=true -v /home/walt/git/pithos-app:/go/src/github.com/gravitational/pithos-app -v /pkg:/gopath/pkg -w /go/src/github.com/gravitational/pithos-app quay.io/gravitational/debian-
venti:go1.12.9-buster make build-pithosctl-docker
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o build/pithosctl cmd/pithosctl/*.go
for dir in bootstrap pithosctl hook; do mkdir -p images/${dir}/bin; cp build/pithosctl images/${dir}/bin/; done                                                                               
walt@work:~/git/pithos-app$ ls -l build/                                                       
total 39188                                                                                    
-rwxr-xr-x 1 root root 40127903 Nov  6 12:14 pithosctl
```

After
```
walt@work:~/git/pithos-app$ make build-pithosctl
docker run --rm=true -u $(id -u):$(id -g) -e GOCACHE=/tmp/.cache -v /home/walt/git/pithos-app:/go/src/github.com/gravitational/pithos-app -v /pkg:/gopath/pkg -w /go/src/github.com/gravitational/pithos-app quay.io/gravitational/debian-venti:go1.12.9-buster make build-pithosctl-docker
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o build/pithosctl cmd/pithosctl/*.go
for dir in bootstrap pithosctl hook; do mkdir -p images/${dir}/bin; cp build/pithosctl images/${dir}/bin/; done
walt@work:~/git/pithos-app$ ls -l build
total 39188
-rwxr-xr-x 1 walt walt 40127903 Nov  6 12:51 pithosctl
```

Testing for the run.sh changes can be seen at https://github.com/gravitational/gravity/pull/2153.

## TODO
 - [x] Validate this pr build successfully completes
 - [x] Validate there are no files owned by anything other than jenkins in the build directory 