### PR TITLE
[1.12.x] Run build/robotest containers as non-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GRAVITY_VERSION ?= 5.5.51
 CLUSTER_SSL_APP_VERSION ?= "0.0.0+latest"
 
 SRCDIR=/go/src/github.com/gravitational/pithos-app
-DOCKERFLAGS=--rm=true -v $(PWD):$(SRCDIR) -v $(GOPATH)/pkg:/gopath/pkg -w $(SRCDIR)
+DOCKERFLAGS=--rm=true -u $$(id -u):$$(id -g) -e GOCACHE=/tmp/.cache -v $(PWD):$(SRCDIR) -v $(GOPATH)/pkg:/gopath/pkg -w $(SRCDIR)
 BUILDIMAGE=quay.io/gravitational/debian-venti:go1.12.9-buster
 
 EXTRA_GRAVITY_OPTIONS ?=

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ $(TARBALL): import $(BUILD_DIR)
 build-app: images | $(BUILD_DIR)
 	sed -i "s/version: \"0.0.0+latest\"/version: \"$(RUNTIME_VERSION)\"/" resources/app.yaml
 	sed -i "s#gravitational.io/cluster-ssl-app:0.0.0+latest#gravitational.io/cluster-ssl-app:$(CLUSTER_SSL_APP_VERSION)#" resources/app.yaml
-	-$(TELE) build -f -o build/installer.tar $(TELE_BUILD_OPTIONS) $(EXTRA_GRAVITY_OPTIONS) resources/app.yaml
+	$(TELE) build -f -o build/installer.tar $(TELE_BUILD_OPTIONS) $(EXTRA_GRAVITY_OPTIONS) resources/app.yaml
 	sed -i "s/version: \"$(RUNTIME_VERSION)\"/version: \"0.0.0+latest\"/" resources/app.yaml
 	sed -i "s#gravitational.io/cluster-ssl-app:$(CLUSTER_SSL_APP_VERSION)#gravitational.io/cluster-ssl-app:0.0.0+latest#" resources/app.yaml
 

--- a/scripts/robotest_run_suite.sh
+++ b/scripts/robotest_run_suite.sh
@@ -25,7 +25,13 @@ export TAG=pithos-$(git rev-parse --short HEAD)
 export GCL_PROJECT_ID=${GCL_PROJECT_ID:-"kubeadm-167321"}
 export GCE_REGION="northamerica-northeast1,us-west1,us-east1,us-east4,us-central1"
 export PATH=$(pwd)/bin:$PATH
-export DOCKER_RUN_FLAGS="--user $(id -u):$(id -g)"
+export DOCKER_RUN_FLAGS=${DOCKER_RUN_FLAGS:-"--rm=true --user=$(id -u):$(id -g)"}
+
+# Work around a bug in https://github.com/gravitational/robotest/blob/v2.1.0/docker/suite/run_suite.sh#L21-L30
+# which mounts a volume inside a volume, resulting in docker creating the inner mountpoint
+# owned by root:root if it does not already exist.
+INSTALLER_BINDIR="$(dirname ${INSTALLER_URL})/bin"
+mkdir -p "${INSTALLER_BINDIR}"
 
 function build_upgrade_step {
   local usage="$FUNCNAME os release storage-driver cluster-size"


### PR DESCRIPTION
Backport https://github.com/gravitational/pithos-app/pull/143 build changes.

This prevents several files from being created with root ownership as part of the build process.