### PR TITLE
Replace cron with supercronic for utils container

### DIFF
--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -19,6 +19,7 @@ ENV TERM=xterm \
 
 ADD rootfs/ /
 COPY --from=builder /usr/src/app/target/*jar-with-dependencies.jar /kubernetes-cassandra.jar
+
 RUN /build.sh && rm /build.sh
 RUN mkfifo --mode 0666 /var/log/cron.log
 

--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -24,6 +24,7 @@ RUN /build.sh && rm /build.sh
 RUN mkfifo --mode 0666 /var/log/cron.log
 
 VOLUME ["/$CASSANDRA_DATA"]
+USER cassandra
 
 # 7000: intra-node communication
 # 7001: TLS intra-node communication

--- a/images/cassandra/rootfs/build.sh
+++ b/images/cassandra/rootfs/build.sh
@@ -58,9 +58,7 @@ cp /tmp/jolokia-${JOLOKIA_VERSION}/agents/jolokia-jvm.jar /usr/local/apache-cass
 
 echo "Downloading and installing telegraf..."
 curl -L https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_amd64.tar.gz | tar -xzf - --strip-components=2 -C / ./telegraf/usr/bin/telegraf
-adduser --disabled-password --no-create-home --gecos '' --disabled-login telegraf
-chown telegraf: /usr/bin/telegraf
-chown -R telegraf: /etc/telegraf
+chown -R cassandra: /etc/telegraf
 
 echo "Downloading jmxterm..."
 curl -L https://sourceforge.net/projects/cyclops-group/files/jmxterm/1.0.0/jmxterm-1.0.0-uber.jar/download -o /jmxterm.jar

--- a/images/cassandra/rootfs/build.sh
+++ b/images/cassandra/rootfs/build.sh
@@ -27,7 +27,6 @@ apt-get update
 apt-get install -y \
     openjdk-8-jre-headless \
     libjemalloc1 \
-    cron \
     curl \
     gawk \
     python \
@@ -65,6 +64,14 @@ chown -R telegraf: /etc/telegraf
 
 echo "Downloading jmxterm..."
 curl -L https://sourceforge.net/projects/cyclops-group/files/jmxterm/1.0.0/jmxterm-1.0.0-uber.jar/download -o /jmxterm.jar
+
+echo "Downloading supercronic..."
+SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.11/supercronic-linux-amd64
+SUPERCRONIC_SHA1SUM=a2e2d47078a8dafc5949491e5ea7267cc721d67c
+
+curl -fsSL "$SUPERCRONIC_URL" -o /usr/local/bin/supercronic
+echo "${SUPERCRONIC_SHA1SUM}"  /usr/local/bin/supercronic | sha1sum -c -
+chmod +x /usr/local/bin/supercronic
 
 rm -rf \
     $CASSANDRA_HOME/*.txt \
@@ -116,14 +123,6 @@ rm -rf \
     /usr/lib/jvm/java-8-openjdk-amd64/man \
     /var/lib/apt/lists/*
 
-touch /etc/cron.d/cassandra /var/run/crond.pid
-
-chown cassandra /init.cql /etc/cron.d/cassandra /var/run/crond.pid
-chmod 666 /var/run/crond.pid
-
-setcap cap_setuid=ep $(which cron)
-setcap cap_setgid=ep $(which cron)
-chmod ug+s $(which cron)
+chown cassandra /init.cql
 
 setcap cap_ipc_lock=+ep /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-

--- a/images/cassandra/rootfs/usr/sbin/start-utils.sh
+++ b/images/cassandra/rootfs/usr/sbin/start-utils.sh
@@ -4,6 +4,6 @@ if [ "x$CRON_SCHEDULE" = "x" ]; then
     CRON_SCHEDULE='0 0 * * *'
 fi
 
-echo -e "$CRON_SCHEDULE cassandra sleep $((RANDOM%30))m && nodetool -p 7199 -h localhost repair" > /tmp/cassandra.cron
+echo -e "$CRON_SCHEDULE sleep $((RANDOM%30))m && nodetool -p 7199 -h localhost repair" > /tmp/cassandra.cron
 
 supercronic /tmp/cassandra.cron

--- a/images/cassandra/rootfs/usr/sbin/start-utils.sh
+++ b/images/cassandra/rootfs/usr/sbin/start-utils.sh
@@ -4,7 +4,6 @@ if [ "x$CRON_SCHEDULE" = "x" ]; then
     CRON_SCHEDULE='0 0 * * *'
 fi
 
-echo -e "PATH=$PATH\n$CRON_SCHEDULE cassandra sleep $((RANDOM%30))m && nodetool -p 7199 -h localhost repair >> /var/log/cron.log 2>&1" > /etc/cron.d/cassandra
+echo -e "$CRON_SCHEDULE cassandra sleep $((RANDOM%30))m && nodetool -p 7199 -h localhost repair" > /tmp/cassandra.cron
 
-# watch /var/log/cron.log restarting if necessary
-cron && tail -f /var/log/cron.log
+supercronic /tmp/cassandra.cron

--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -229,6 +229,10 @@ spec:
           env:
             - name: CRON_SCHEDULE
               value: "15 2 * * *"
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
         - image: cassandra:latest
           name: cassandra-metrics
           command: ["/usr/bin/dumb-init", "/usr/sbin/start-telegraf.sh"]

--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -166,8 +166,6 @@ spec:
           name: cassandra
           imagePullPolicy: Always
           securityContext:
-            # 1000 is the cassandra user UID inside the cassandra container
-            runAsUser: 1000
             readOnlyRootFilesystem: false
             capabilities:
               add:
@@ -225,8 +223,6 @@ spec:
             - name: cassandra-ssl
               mountPath: /etc/ssl/cassandra
         - image: cassandra:latest
-          securityContext:
-            runAsUser: -1
           name: cassandra-utils
           command: ["/usr/bin/dumb-init", "/usr/sbin/start-utils.sh"]
           imagePullPolicy: Always
@@ -234,8 +230,6 @@ spec:
             - name: CRON_SCHEDULE
               value: "15 2 * * *"
         - image: cassandra:latest
-          securityContext:
-            runAsUser: -1
           name: cassandra-metrics
           command: ["/usr/bin/dumb-init", "/usr/sbin/start-telegraf.sh"]
           imagePullPolicy: Always


### PR DESCRIPTION
# Changes
Replace cron with container-ready [supercronic](https://github.com/aptible/supercronic) project.

# Testing done
1. Install cluster
2. Change cron schedule to force execution
3. Check logs for errors or for successful execution:

``` shell
sergei-dev-0:/$ kubectl logs cassandra-2 -c cassandra-utils -f                                                                                              time="2020-11-26T07:14:35Z" level=info msg="read crontab: /tmp/cassandra.cron"
time="2020-11-26T07:17:00Z" level=info msg=starting iteration=0 job.command="sleep 8m && nodetool -p 7199 -h localhost repair" job.position=0 job.schedule="17 * * * *"

time="2020-11-26T07:25:00Z" level=info msg="grep: /etc/cassandra/jvm.options: No such file or directory" channel=stderr iteration=0 job.command="sleep 8m && nodetool -p 7199 -h localhost repair" job.position=0 job.schedule="17 * * * *"
                                                                                                                                                        time="2020-11-26T07:25:01Z" level=info msg="[2020-11-26 07:25:01,316] Starting repair command #1 (7ed07250-2fb8-11eb-8330-07cb9da92deb), repairing keyspace storage with repair options (parallelism: parallel, primary range: false, incremental: true, job threads: 1, ColumnFamilies: [], dataCenters: [], hosts: [], # of ranges: 96, pull repair: false)" channel=stdout iteration=0 job.command="sleep 8m && nodetool -p 7199 -h localhost repair" job.position=0 job.schedule="17 * * * *"

--- skipped log lines ---

time="2020-11-26T07:25:02Z" level=info msg="job succeeded" iteration=0 job.command="sleep 8m && nodetool -p 7199 -h localhost repair" job.position=0 job.schedule="17 * * * *"
```