### PR TITLE
Add Drone CI for Pull Requests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,72 @@
+---
+kind: pipeline
+type: kubernetes
+name: pr
+
+trigger:
+  event:
+  - pull_request
+
+environment:
+  STATEDIR: /drone/src/state
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: download binaries
+    image: docker:git
+    commands:
+      - apk add --no-cache make curl
+      - make download-binaries
+  - name: login to opscenter
+    image: docker:git
+    environment:
+      OPS_URL:
+        from_secret: OPS_URL
+      API_KEY:
+        from_secret: OPS_API_KEY_RO
+    commands:
+      # tele is built against glibc. Alpine's musl libc is glibc compatible, but needs to be linked into place.
+      - apk add --no-cache libc6-compat
+      - ./bin/tele login --state-dir=$STATEDIR --hub $OPS_URL --token=$API_KEY
+  - name: build
+    image: docker:git
+    environment:
+      OPS_URL:
+        from_secret: OPS_URL
+    commands:
+      - apk add --no-cache make libc6-compat
+      # add binaries downloaded in "download binaries" step to path
+      - export PATH=$PATH:$(pwd)/bin
+      - export EXTRA_GRAVITY_OPTIONS=--state-dir=$STATEDIR
+      - make build-app
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+---
+kind: signature
+hmac: a8e8a65ff76b3b29c82147758b930c97614c295df9fd9f9ffb059e0e88314e63
+
+...

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ properties([
            description: 'Gravity options to add when calling tele'),
     string(name: 'TELE_BUILD_EXTRA_OPTIONS',
            defaultValue: '',
-           description: 'Extraoptions to add when calling tele build'),
+           description: 'Extra options to add when calling tele build'),
     booleanParam(name: 'ADD_GRAVITY_VERSION',
                  defaultValue: false,
                  description: 'Appends "-${GRAVITY_VERSION}" to the tag to be published'),

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-export VERSION ?= $(shell ./version.sh)
+ifeq ($(origin VERSION), undefined)
+# avoid ?= lazily evaluating version.sh (and thus rerunning the shell command several times)
+VERSION := $(shell ./version.sh)
+endif
+
 REPOSITORY := gravitational.io
 NAME := pithos-app
 OPS_URL ?= https://opscenter.localhost.localdomain:33009

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TELE ?= $(shell which tele)
 GRAVITY ?= $(shell which gravity)
 RUNTIME_VERSION ?= $(shell $(TELE) version | awk '/^[vV]ersion:/ {print $$2}')
 INTERMEDIATE_RUNTIME_VERSION ?=
-GRAVITY_VERSION ?= 5.5.21
+GRAVITY_VERSION ?= 7.0.23
 CLUSTER_SSL_APP_VERSION ?= "0.0.0+latest"
 
 SRCDIR=/go/src/github.com/gravitational/pithos-app

--- a/Makefile
+++ b/Makefile
@@ -140,3 +140,7 @@ clean:
 .PHONY: push
 push:
 	$(TELE) push -f $(EXTRA_GRAVITY_OPTIONS) $(BUILD_DIR)/installer.tar
+
+.PHONY: get-version
+get-version:
+	@echo $(VERSION)

--- a/images/Makefile
+++ b/images/Makefile
@@ -57,7 +57,7 @@ pithos:
 
 .PHONY: hook
 hook:
-	$(eval CHANGESET = $(shell echo $$VERSION | sed -e 's/[\.]//g'))
+	$(eval CHANGESET = $(shell echo '$(VERSION)' | sed -e 's/[\.]//g'))
 	if [ -z "$(CHANGESET)" ]; then \
 		echo "CHANGESET is not set"; exit 1; \
 	fi;

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,7 @@
 
 # this versioning algo:
 # keeps tag as is in case if this version is an equal match
-# otherwise adds .<number of commits since last tag>
+# otherwise adds -dev.<number of commits since last tag>
 
 SHORT_TAG=`git describe --abbrev=0 --tags`
 LONG_TAG=`git describe --tags`
@@ -12,7 +12,7 @@ COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 if [ "$LONG_TAG" = "$SHORT_TAG" ] ; then  # the current commit is tagged as a release
     echo "$SHORT_TAG"
 elif echo "$SHORT_TAG" | grep -Eq ".*-.*"; then  # the current commit is a descendant of a pre-release version (e.g. rc, alpha, or beta)
-    echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
+    echo "$SHORT_TAG-dev.${COMMITS_SINCE_LAST_TAG}"
 else   # the current commit is a descendant of a regular version
-    echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
+    echo "$SHORT_TAG-dev.${COMMITS_SINCE_LAST_TAG}"
 fi

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # this versioning algo:
 # keeps tag as is in case if this version is an equal match
@@ -9,10 +9,10 @@ LONG_TAG=`git describe --tags`
 COMMIT_WITH_LAST_TAG=`git show-ref --tags --dereference | grep "refs/tags/${SHORT_TAG}^{}" | awk '{print $1}'`
 COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 
-if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then
+if [ "$LONG_TAG" = "$SHORT_TAG" ] ; then  # the current commit is tagged as a release
     echo "$SHORT_TAG"
-elif [[ "$SHORT_TAG" != *-* ]] ; then
+elif echo "$SHORT_TAG" | grep -Eq ".*-.*"; then  # the current commit is a descendant of a pre-release version (e.g. rc, alpha, or beta)
     echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
-else
+else   # the current commit is a descendant of a regular version
     echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
 fi


### PR DESCRIPTION
## Summary
This patch adds an intial Drone CI config that builds the pithos cluster image upon PR.

It does not presently run robotest or publish artifacts.  Robotest will be added in a later PR and publishing is not needed in Drone.

## Testing Done
Most importantly, the Drone CI build on this PR passes.
Builds along the way found here: https://drone.gravitational.io/gravitational/pithos-app/

## Notes

The changes to version.sh are for two reasons:

1) to accomodate alpine's ash or generic posix shells, instead of bash
2) to generate semver compliant versions like `1.13.6-dev.9`.  Previously, version.sh generated dotted quads for builds after a tag -- e.g. `1.13.6.9`.  Tele would choke on these generating an error like the following:

```
[ERROR]: app version must be in semver format, got "1.13.6.10"
        strconv.ParseInt: parsing "6.10": invalid syntax
```

We could go a bit further, and pick up [robotest's version file](https://github.com/gravitational/robotest/blob/3774f8641439b19c4e0e598db8f87c52ea0e4817/version.sh), which auto increments minor versions and includes build metadata (making it dev builds explicit about which commit they came from).  This is up to you @UnderGreen -- the current implementation works, but generates out of order semvers for development versions.

The ci-ops user is a new one provisioned for this job, with the following role permissions:

```
kind: role
metadata:
  name: ci-user-ro
spec:
  allow:
    logins:
    - ci-user
    node_labels:
      '*': '*'
    rules:
    - resources:
      - repository
      verbs:
      - read
      - list
    - resources:
      - app
      verbs:
      - read
      - list
  options:
    max_session_ttl: 2h0m0s
version: v3
```