### PR TITLE
Add robotest to Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -49,10 +49,40 @@ steps:
       # add binaries downloaded in "download binaries" step to path
       - export PATH=$PATH:$(pwd)/bin
       - export EXTRA_GRAVITY_OPTIONS=--state-dir=$STATEDIR
+      - export INTERMEDIATE_RUNTIME_VERSION=6.1.43
       - make build-app
     volumes:
       - name: dockersock
         path: /var/run
+  - name: robotest
+    image: docker:git
+    when: # do not run robotest on PRs from forks, as GCP provisioning creds would be leaked
+      repo:
+      - gravitational/pithos-app
+    environment:
+      GCP_ROBOTEST_CREDENTIALS:
+        from_secret: GCP_ROBOTEST_CREDENTIALS
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      # These files need to be in a volume that the docker service has access to
+      # We choose /tmp to accommodate https://github.com/gravitational/robotest/blob/3774f8641439b19c4e0e598db8f87c52ea0e4817/docker/suite/run_suite.sh#L106
+      SSH_KEY: /tmp/secrets/robotest
+      SSH_PUB: /tmp/secrets/robotest.pub
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/secrets/gcp.json
+    commands:
+      - apk add --no-cache make bash aws-cli
+      - mkdir -p $(dirname $SSH_KEY)
+      - ssh-keygen -t ed25519 -N '' -f $SSH_KEY
+      - echo "$GCP_ROBOTEST_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+      - make robotest-run-suite
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
 
 services:
   - name: run docker daemon
@@ -61,12 +91,16 @@ services:
     volumes:
       - name: dockersock
         path: /var/run
+      - name: dockertmp
+        path: /tmp
 
 volumes:
   - name: dockersock
     temp: {}
+  - name: dockertmp
+    temp: {}
 ---
 kind: signature
-hmac: a8e8a65ff76b3b29c82147758b930c97614c295df9fd9f9ffb059e0e88314e63
+hmac: 04c85f9f78dbe23a7b30a011bfda8fe6f8a485593cd7b24f6c403d3ce6ba2fe5
 
 ...

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ properties([
            defaultValue: '1',
            description: 'How many times to repeat each test.'),
     string(name: 'ROBOTEST_VERSION',
-           defaultValue: '2.1.1',
+           defaultValue: '2.2.0',
            description: 'Robotest tag to use.'),
     string(name: 'OPS_URL',
            defaultValue: 'https://ci-ops.gravitational.io',

--- a/robotest/pr_config.sh
+++ b/robotest/pr_config.sh
@@ -9,7 +9,7 @@ source $(dirname $0)/utils.sh
 declare -A UPGRADE_MAP
 
 # TODO (Sergei): enable upgrades from recommended tags
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 1.12.x))]="ubuntu:18" # this branch
+UPGRADE_MAP[1.12.13]="ubuntu:18" # this branch
 
 # via intermediate upgrade
 UPGRADE_MAP[1.12.5]="centos:7"

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -55,7 +55,9 @@ export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
 mkdir -p $UPGRADE_FROM_DIR
 for release in ${!UPGRADE_MAP[@]}; do
   if [ ! -f $UPGRADE_FROM_DIR/$(tag_to_tarball ${release}) ]; then
-      aws s3 cp s3://builds.gravitational.io/pithos/$(tag_to_tarball ${release}) $UPGRADE_FROM_DIR/$(tag_to_tarball ${release})
+      # aws s3 cp has incredibly verbose progress, disable progress for the sake of concise CI logs
+      [[ -z ${CI:-} ]] || S3_FLAGS=--no-progress
+      aws s3 cp ${S3_FLAGS:-} s3://builds.gravitational.io/pithos/$(tag_to_tarball ${release}) $UPGRADE_FROM_DIR/$(tag_to_tarball ${release})
   fi
 done
 

--- a/robotest/run.sh
+++ b/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$(pwd)/build/installer.tar
 export GRAVITY_URL=$(pwd)/bin/gravity


### PR DESCRIPTION
## Summary

This PR adds a robotest step to our Drone PR pipeline, mostly independent of the Jenkins infrastructure.

## Testing Done
Lots of runs in my branch. https://drone.gravitational.io/gravitational/pithos-app/38/1/8 is a Fine one to look at. More importantly, the PR build on this job should run the robotest step and pass.

## Risks

@webvictim : Because robotest currently runs in the kubeadm account and needs compute admin privileges, robotest's GCP credentials could escalate to ownership of Drone -- which gets access to pretty much all important source code and publishing infrastructure.  As such, I've disabled PRs from forks on this repo for the time being.  I'll look into reenabling CI on PR once robotest has been moved out of kubeadm (likely when it goes to an AWS sandbox).

Alternatively, I could set up some conditionals to allow PRs from forks to run the build, but not robotest. Some prior discussion here: https://discourse.drone.io/t/how-to-identity-a-pr-coming-from-a-forked-repo/7782/3

## Notes
The AWS creds are readonly for s3://builds.gravitational.io/pithos, provisioned in https://drone.gravitational.io/gravitational/pithos-app/38/1/8.  The token/id can be found in 1Password by searching for `drone-ci-s3-builds-gravitational-io-pithos-readonly` 

For the GCP creds, I defined a role with privileges equivalent to the current `robotest-runner` user, and then created a new `drone-pithos-robotest` user with this role. I considered doing this via Terraform -- but robotest + GCP is a limited time offering due to security and cross-cloud data transfer concerns.  The extra effort for infrastructure as code wasn't worth the delay to the jenkins migration.  Find the json token for this user in 1Password by searching `drone-pithos-robotest`.

None of the credentials are shared, though robotest running does depend on some preconfigured state (network, subnets, datasinks) latent in the kubeadm project that won't be addressed until robotest is migrated out of that project.