### PR TITLE
Backport 1.12.x: Replace cron with supercronic for utils container (#147)

### DIFF
--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -19,10 +19,12 @@ ENV TERM=xterm \
 
 ADD rootfs/ /
 COPY --from=builder /usr/src/app/target/*jar-with-dependencies.jar /kubernetes-cassandra.jar
+
 RUN /build.sh && rm /build.sh
 RUN mkfifo --mode 0666 /var/log/cron.log
 
 VOLUME ["/$CASSANDRA_DATA"]
+USER cassandra
 
 # 7000: intra-node communication
 # 7001: TLS intra-node communication

--- a/images/cassandra/rootfs/build.sh
+++ b/images/cassandra/rootfs/build.sh
@@ -27,7 +27,6 @@ apt-get update
 apt-get install -y \
     openjdk-8-jre-headless \
     libjemalloc1 \
-    cron \
     curl \
     gawk \
     python \
@@ -62,12 +61,18 @@ cp /tmp/jolokia-${JOLOKIA_VERSION}/agents/jolokia-jvm.jar /usr/local/apache-cass
 
 echo "Downloading and installing telegraf..."
 curl -L https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_amd64.tar.gz | tar -xzf - --strip-components=2 -C / ./telegraf/usr/bin/telegraf
-adduser --disabled-password --no-create-home --gecos '' --disabled-login telegraf
-chown telegraf: /usr/bin/telegraf
-chown -R telegraf: /etc/telegraf
+chown -R cassandra: /etc/telegraf
 
 echo "Downloading jmxterm..."
 curl -L https://sourceforge.net/projects/cyclops-group/files/jmxterm/1.0.0/jmxterm-1.0.0-uber.jar/download -o /jmxterm.jar
+
+echo "Downloading supercronic..."
+SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.11/supercronic-linux-amd64
+SUPERCRONIC_SHA1SUM=a2e2d47078a8dafc5949491e5ea7267cc721d67c
+
+curl -fsSL "$SUPERCRONIC_URL" -o /usr/local/bin/supercronic
+echo "${SUPERCRONIC_SHA1SUM}"  /usr/local/bin/supercronic | sha1sum -c -
+chmod +x /usr/local/bin/supercronic
 
 rm -rf \
     $CASSANDRA_HOME/*.txt \
@@ -119,13 +124,6 @@ rm -rf \
     /usr/lib/jvm/java-8-openjdk-amd64/man \
     /var/lib/apt/lists/*
 
-touch /etc/cron.d/cassandra /var/run/crond.pid
-
-chown cassandra /init.cql /etc/cron.d/cassandra /var/run/crond.pid
-chmod 666 /var/run/crond.pid
-
-setcap cap_setuid=ep $(which cron)
-setcap cap_setgid=ep $(which cron)
-chmod ug+s $(which cron)
+chown cassandra /init.cql
 
 setcap cap_ipc_lock=+ep /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java

--- a/images/cassandra/rootfs/usr/sbin/start-utils.sh
+++ b/images/cassandra/rootfs/usr/sbin/start-utils.sh
@@ -4,7 +4,6 @@ if [ "x$CRON_SCHEDULE" = "x" ]; then
     CRON_SCHEDULE='0 0 * * *'
 fi
 
-echo -e "PATH=$PATH\n$CRON_SCHEDULE cassandra sleep $((RANDOM%30))m && nodetool -p 7199 -h localhost repair >> /var/log/cron.log 2>&1" > /etc/cron.d/cassandra
+echo -e "$CRON_SCHEDULE sleep $((RANDOM%30))m && nodetool -p 7199 -h localhost repair" > /tmp/cassandra.cron
 
-# watch /var/log/cron.log restarting if necessary
-cron && tail -f /var/log/cron.log
+supercronic /tmp/cassandra.cron

--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -238,6 +238,10 @@ spec:
                 secretKeyRef:
                   name: telegraf-influxdb-creds
                   key: password
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
         - image: cassandra:latest
           name: cassandra-metrics
           command: ["/usr/bin/dumb-init", "/usr/sbin/start-telegraf.sh"]


### PR DESCRIPTION
* Replace cron with supercronic

* Use cassandra user for all containers

* Enable capability to allow run java

* Do not use user name for cron schedule

### Testing done

``` shell
kubectl logs cassandra-0 -c cassandra-utils
time="2021-01-25T21:28:30Z" level=info msg="read crontab: /tmp/cassandra.cron"
```

Cassandra cluster status:

``` shell
kubectl exec pithosctl-6f9f498ff7-2tlhp -- pithosctl status
NAME            READY   STATUS          IP              NODE            AGE
cassandra-0     3/3     Running         10.244.92.11    172.28.128.5    4m
cassandra-1     3/3     Running         10.244.32.12    172.28.128.3    3m
cassandra-2     3/3     Running         10.244.74.10    172.28.128.4    2m

STATUS  STATE   ADDRESS         LOAD            OWNS    HOSTID
Up      Normal  10.244.32.12    113.19KiB       100%    7973b71f-f8af-4987-8d73-4164121f82be
Up      Normal  10.244.74.10    139.26KiB       100%    4ee6a052-2803-4fe8-8d0a-39f2edda86cf
Up      Normal  10.244.92.11    92.3KiB         100%    d9f9500b-15ff-4950-8ff4-f1541814b95c

Cluster status: Healthy
```