### PR TITLE
[1.12.x ]Fix permission issues for installations with non-default UID

### DIFF
--- a/resources/pithos-initialize.yaml
+++ b/resources/pithos-initialize.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       securityContext:
-          runAsUser: -1
+          runAsUser: 0
       containers:
         - image: cassandra:latest
           name: pithos-initialize

--- a/resources/pithos.yaml
+++ b/resources/pithos.yaml
@@ -137,7 +137,8 @@ spec:
       nodeSelector:
         pithos-role: node
       securityContext:
-          runAsUser: -1
+        # hardcoded pithos user ID in the docker container
+        runAsUser: 1000
       containers:
       - image: pithos:latest
         name: pithos


### PR DESCRIPTION
While installing the application with non-default UID/GID installation fails for pithos and pithos-initialize components.